### PR TITLE
Explicitly declare font size as em.

### DIFF
--- a/public/css/help.css
+++ b/public/css/help.css
@@ -90,7 +90,7 @@ pre {
   padding: .576em 1.2em .864em .972em;
   margin: 0 0 1.667em;
   line-height: 1.475;
-  font-size: 1.05;
+  font-size: 1.05em;
   color: #555;
   border: 1px solid #e9e9e9;
   border-radius: 2px;


### PR DESCRIPTION
Firefox 31 likes to interpret an undefined size as pixels, so the code was unreadably small. 
