### PR TITLE
Update jsbin help and blog platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 before_script:
 - npm install
 node_js:
-- "0.10"
+- "7"
 deploy:
   on: master
   api_key:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "harp": "*",
-    "harp-static": "~0.1.0"
+    "harp-static": "~0.1.0",
+    "jstransformer-marked": "^1.0.2"
   }
 }

--- a/public/404.jade
+++ b/public/404.jade
@@ -1,6 +1,6 @@
 h1 The page you were looking for doesn't exist...yet?
 
-:markdown
+:marked
   The JS Bin learn site is all available on [github](https://github.com/jsbin/learn), so it's possible you were after a page that doesn't exist *yet*, so if you're feeling brave, we'd love for you to go ahead and send us a pull request for the page you were looking for.
 
   If you had a specific question that wasn't answered, or indeed this is a bug (and you expected to find a specific page), please do take a minute to [file an issue](https://github.com/jsbin/learn/issues/new) to help us help you.

--- a/public/_partials/help-posts.jade
+++ b/public/_partials/help-posts.jade
@@ -7,7 +7,7 @@
 -   });
 - }
 
-block
+block content
   - var f = filter || current.path.slice(-2, -1)[0];
   ul.links
     for post in sortByTitle(public.help._data)

--- a/public/_partials/layout.jade
+++ b/public/_partials/layout.jade
@@ -1,12 +1,17 @@
-static = ''
-if environment == "production"
-  static = 'https://learn.jsbin.com'
-if environment == "test"
-  static = 'http://localhost:9000'
+- var getEnvironment = function () {
+-   if (environment == "production") {
+-     return 'https://learn.jsbin.com';
+-   }
+-   else if (environment == "test") {
+-     return 'http://localhost:9000';
+-   }
+-   else {
+-     return '';
+-   }
+- }
+- var static = getEnvironment()
 
-pagetitle = siteTitle
-if title
-  pagetitle = title + ' - ' + siteTitle
+- var pagetitle = title ? title + ' - ' + siteTitle : siteTitle
 
 //- sad panda code: the path of the partial is relative to the request
 //- *not* the file being included (ie. this one).
@@ -14,7 +19,7 @@ if title
 //- of periods to add for path navigation.
 - function repeat(str, num) { return new Array( num + 1 ).join( str ); }
 
-prefix = repeat('.', current.path.length).split('..').join('../')
+- var prefix = repeat('.', current.path.length).split('..').join('../')
 
 doctype
 html(id="#{current.path.join('-')}-page")

--- a/public/blog/index.jade
+++ b/public/blog/index.jade
@@ -10,5 +10,5 @@ ul.posts
       a(href="/blog/#{ post.slug }")= post.title
       p.extract
         != partial(post.slug).split('<p>')[1].replace(/<\/p>\s*.*/m, '').replace(/(<([^>]+)>)/ig, '').trim()
-        &nbsp;
+        | &nbsp;
         a(href="/blog/#{ post.slug }") Read post

--- a/public/help/_layout.jade
+++ b/public/help/_layout.jade
@@ -14,5 +14,5 @@ block content
           a(href="#{slug}")= post.title
           br
           != partial(slug).split('<p>')[1].replace(/<\/p>\s*.*/m, '').replace(/(<([^>]+)>)/ig, '').trim()
-          &nbsp;
+          | &nbsp;
           a(href="#{ slug }") Read&nbsp;more

--- a/public/help/faq.md
+++ b/public/help/faq.md
@@ -42,7 +42,7 @@ Yes. See the [Ajax debugging video][5] for a demo. Or, it's as simple as removin
 
 ## IE6?
 
-I'm afraid not, but the application is open source, so if you think you can get it working - please go ahead: [<github.com/jsbin/jsbin>][6]
+I'm afraid not, but the application is open source, so if you think you can get it working - please go ahead: [<github.com/jsbin/jsbin][6]
 
 ## How do I delete my account?
 

--- a/public/legals/index.jade
+++ b/public/legals/index.jade
@@ -15,7 +15,7 @@ small Last updated June 12, 2014
         td
           h2 1.1.
         td
-          :markdown
+          :marked
             The following defined terms apply in this agreement.
 
             **Account**:  means your account enabling you to access the Services relevant to your subscription being one, some or all of the following accounts - “Anonymous User”, “Free User” or “Pro User” or such other package as JS Bin may provide from time to time.
@@ -35,19 +35,19 @@ small Last updated June 12, 2014
         td
           h2 1.2.
         td
-          :markdown
+          :marked
             Any other defined terms (introduced as such by capitalisation in bold) which appear later in these Terms will take the meaning ascribed to them.
       tr
         td
           h2 1.3.
         td
-          :markdown
+          :marked
             A reference to writing or written means to email.
 
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       This mighty document is our legal terms. Exciting stuff, but worth taking a few minutes to look through to understand what it means to you.
 
       We've tried to summarise the main points of each section, to make our terms a little more digestable.
@@ -64,36 +64,36 @@ small Last updated June 12, 2014
         td
           h2 2.1.
         td
-          :markdown
+          :marked
             These Terms are a contract between you, the User, and JS Bin Limited (“we” or “us”), a company incorporated in England and Wales under company number 08998555 with its registered office at 44 Burstead Close, Brighton BN1 7HT (‘**JS Bin**’).
       tr
         td
           h2 2.2.
         td
-          :markdown
+          :marked
             JS Bin operates jsbin.com which includes other domains from time to time which direct to jsbin.com via DNS aliases (the ‘**JS Bin Site**’) and the JS Bin creation service contained therein. By using the JS Bin Site and any services accessible from the JS Bin Site, you are agreeing to be bound by these Terms. If you do not agree to these Terms or any part thereof, your only remedy is to not use the JS Bin Site or any services or products offered on the JS Bin Site or on any other platform, including mobile applications, offered by JS Bin (collectively, the ‘**Service**’ or ‘**Services**’).
       tr
         td
           h2 2.3.
         td
-          :markdown
+          :marked
             Breach of these Terms or any part thereof will entitle JS Bin to terminate your right to use the Service. Any account you may have created will be deleted. JS Bin reserves the right to refuse provision of the Service to anyone at their complete discretion.
       tr
         td
           h2 2.4.
         td
-          :markdown
+          :marked
             You agree and accept that your use of the Service is entirely at your own risk.
       tr
         td
           h2 2.5.
         td
-          :markdown
+          :marked
             These Terms will apply for as long as you use the JS Bin Site and/or the Services. Any part of these Terms that by necessity or implication are to continue after your use of the JS Bin Site or the Services ends (including the licence under clause 5.1) shall continue in force.
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       There are a few rules which we need to play by. We run jsbin.com and all the sites under that domain.
 
       If you break the rules by Being a Jerk™ then we reserve the right to remove your user and your Bins from JS&nbsp;Bin.
@@ -109,38 +109,38 @@ small Last updated June 12, 2014
         td
           h2 3.1.
         td
-          :markdown
+          :marked
             In order to create an Account on the JS Bin Site you must agree to be bound by these Terms and you must provide such information as is reasonably requested by JS Bin during the registration process. You warrant the accuracy and completeness of such information while you are using the Service. If you operate as an Anonymous User and do not register and create an Account you will still be bound by these Terms by virtue of your use and the reasonable implication that such use of the Services and functionality provided by the JS Bin Site would require acceptance of reasonable Terms of Use such as these.
       tr
         td
           h2 3.2.
         td
-          :markdown
+          :marked
             Your Account will feature the Services which you select from the packages available to Users from time to time (currently Anonymous User, Free User and Pro User) and your choice of Account will determine whether or not your Bins will be available for public dissemination or whether you can elect to keep them private. You can upgrade your Account and similarly you can downgrade it at your discretion subject only to the payment terms for any paid for Account.
       tr
         td
           h2 3.3.
         td
-          :markdown
+          :marked
             You are responsible for maintaining the security of your Account and password. You agree that you shall be solely responsible for any loss or damage resulting from failure to comply with this obligation.
       tr
         td
           h2 3.4.
         td
-          :markdown
+          :marked
             You shall use all reasonable endeavours to prevent any unauthorised access to, or use of, the Services and/or the Documentation and, in the event of any such unauthorised access or use, promptly notify JS Bin.
       tr
         td
           h2 3.5.
         td
           //-One person or legal entity may not maintain more than one Account.
-          :markdown
+          :marked
             Accounts registered by ‘bots’ or other automated methods are not permitted.
 
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       If you use JS Bin, you're bound by these terms. If you create an account, please use your own email address.
 
       Pro (aka "paid for accounts") accounts let you create private Bins, otherwise all your Bins are public by default.
@@ -154,12 +154,12 @@ small Last updated June 12, 2014
         td
           h2 3.6.
         td
-          :markdown
+          :marked
             You are responsible for all content, code, features, comments, graphics or text that you may post on the JS Bin Site (the ‘**Content**’) and activity that occurs under your Account (even when Content is posted by others who have access to your Account).
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       You are responsible for the content in your Bins. Don't go infringing on other people's copyrights.
 
   hr
@@ -174,25 +174,25 @@ small Last updated June 12, 2014
         td
           h2 4.1.
         td
-          :markdown
+          :marked
             JS Bin hereby grants you a non-exclusive, non-transferable, worldwide right to access and use the JS Bin Site, solely with supported browsers through the Internet for your own internal purposes, subject to these Terms.
       tr
         td
           h2 4.2.
         td
-          :markdown
+          :marked
             You may not permit the JS Bin Site to be used by or for the benefit of any third parties.
       tr
         td
           h2 4.3.
         td
-          :markdown
+          :marked
             Nothing in these Terms shall be construed to grant you any right to transfer or assign rights to access or use the JS Bin Site.
 
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       You can use JS Bin on jsbin.com. Also, JS Bin is [open source](http://github.com/jsbin/jsbin) and MIT licensed, so you can use it where you want too.
 
   hr
@@ -207,18 +207,18 @@ small Last updated June 12, 2014
         td
           h2 5.1.
         td
-          :markdown
+          :marked
             Subject to clause 5.2, you hereby grant JS Bin and other Users of the Services a worldwide, non-exclusive, royalty-free licence (with the right to sub-licence) to use, copy, reproduce, process, adapt, modify, publish, transmit, display and distribute Content you submit, post or display on the JS Bin Site in any and all media or distribution methods (now known or later developed). Such Content shall be licensed upon the terms of the [MIT licence](http://jsbin.mit-license.org).
       tr
         td
           h2 5.2.
         td
-          :markdown
+          :marked
             If you specifically save a Bin as private on the JS Bin Site, and that Bin has never been public on the JS Bin Site or anywhere else, the code in that particular Bin is unlicensed.
    .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       Public Bins you build on JS Bin are MIT licensed, meaning other people are free to use it for whatever they like as long as that is also [MIT licensed](http://jsbin.mit-license.org). Don't put anything on JS Bin where that wouldn't be okay. Private Bins are un-licensed so that you may apply your own license and retain direct ownership.
 
    .legal
@@ -227,12 +227,12 @@ small Last updated June 12, 2014
         td
           h2 5.3.
         td
-          :markdown
+          :marked
             You agree that the licence in clause 5.1 includes the right for JS Bin and other users of the Services to make your Content available to others for the publication, distribution, syndication, or broadcast of such Content on other media and services, subject to our terms and conditions for such Content use. Such additional uses by JS Bin or others may be made with no compensation paid to you with respect to the Content that you submit, post, transmit or otherwise make available through the Services.
    .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       People don't have to pay to see your Bins.
 
    .legal
@@ -241,12 +241,12 @@ small Last updated June 12, 2014
         td
           h2 5.4.
         td
-          :markdown
+          :marked
             JS Bin may modify or adapt your Content in order to transmit, display or distribute it over computer networks and in various media and/or make changes to your Content as are necessary to conform and adapt that Content to any requirements or limitations of any networks, devices, services or media.
    .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       People can create clones of your Bins.
 
    .legal
@@ -255,7 +255,7 @@ small Last updated June 12, 2014
         td
           h2 5.5.
         td
-          :markdown
+          :marked
             You warrant, represent and agree that you have the right to grant JS Bin the licence in clause 5.1. You also represent, warrant and agree that you have not and will not contribute any Content that:
 
             1. infringes or otherwise interferes with any copyright or trade mark of another party;
@@ -263,8 +263,8 @@ small Last updated June 12, 2014
             * infringes any intellectual property right of another or the privacy or publicity rights of another.
    .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       Don't infringe on other people's copyright.
 
    .legal
@@ -273,7 +273,7 @@ small Last updated June 12, 2014
         td
           h2 5.6.
         td
-          :markdown
+          :marked
             You are responsible for your use of the Service, for any Content you provide, and for any consequences thereof, including the use of your Content by other users and third party partners. You understand that your Content may be republished and if you do not have the right to submit Content for such use, it may subject you to liability. JS Bin will not be responsible or liable for any use of your Content in accordance with these Terms.
    .legal
     table
@@ -281,13 +281,13 @@ small Last updated June 12, 2014
         td
           h2 5.7.
         td
-          :markdown
+          :marked
             JS Bin cannot monitor or control the Content posted via the Services. Any use of or reliance on the Content posted via the Services or obtained by your through the Services is at your own risk. We do not endorse, support, represent or guarantee the completeness, truthfulness, accuracy, or reliability of any Content or communications posted via the Services. You recognise that by using the Services, you may be exposed to Content that may be offensive, harmful, inaccurate or otherwise inappropriate and, whilst we may act to remove it where we are notified and deem it necessary or appropriate to do so or where a third party with legal authority demands that we do so, we are not responsible for it. Under no circumstances will JS Bin be liable in any way for any Content, including but not limited to, any errors or omissions in any Content, or any loss of damage of any kind incurred as a result of the use of the Content made available via the Services.
 
    .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       We don't monitor what you post on JS Bin, nor are liable for what's posted, so if you see something that breaks the rules, [please let us know](mailto:jsbin@leftlogic.com).
 
 
@@ -303,37 +303,37 @@ small Last updated June 12, 2014
         td
           h2 6.1.
         td
-          :markdown
+          :marked
             A valid credit card is required for paying Accounts. The JS Bin Site is billed in advance on a monthly basis in accordance with our pricing schedule and all payments are non-refundable. There will be no refunds or credits for partial months of Service, upgrade/downgrade refunds, or refunds for months unused with an open Account.
       tr
         td
           h2 6.2.
         td
-          :markdown
+          :marked
             You will be billed for your first month immediately upon signing up for a paying Account. After signing up for a paying Account, you will be billed monthly starting on the 30th day after your Account was initially created. You will be billed for your first month immediately upon upgrading to a paying Account or a higher level Account. For any upgrade or downgrade in Account level, your credit card will automatically be charged a pro-rated fee for the new level and subsequent months billed at the full rate for the chosen type of Account.
       tr
         td
           h2 6.3.
         td
-          :markdown
+          :marked
             Downgrading your JS Bin Account may cause loss of content, features, or capacity of your Account. JS Bin does not accept any liability for such loss.
       tr
         td
           h2 6.4.
         td
-          :markdown
+          :marked
             Prices of all JS Bin Accounts, including but not limited to monthly subscription fees to the applicable Account, are subject to change upon 30 days notice from JS Bin. Such notice may be given at any time by posting the changes to the JS Bin Site.
       tr
         td
           h2 6.5.
         td
-          :markdown
+          :marked
             All fees are exclusive of all taxes, levies, or duties imposed by taxing authorities, and you shall be responsible for payment of all such taxes, levies, or duties, excluding only United Kingdom sales taxes. You agree to pay for any such taxes that might be applicable to your use of the Services and payments made by you herein.
 
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       All sales are final. You'll be billed on the 30th day after creating a paid for account.
 
       If you downgrade, you will lose access to Pro features.
@@ -351,21 +351,21 @@ small Last updated June 12, 2014
         td
           h2 7.1.
         td
-          :markdown
+          :marked
             Subject to the other Terms, JS Bin undertakes to use its reasonable endeavours to provide that the Services will be available for use and in accordance with the Documentation.
       tr
         td
           h2 7.2.
         td
-          :markdown
+          :marked
             The undertaking at clause 7.1 shall not apply to the extent of any non-conformance which is caused by use of the Services contrary to the JS Bin's instructions, or modification or alteration of the Services by any party other than JS Bin or JS Bin's duly authorised contractors or agents. If the Services do not conform with the foregoing undertaking, JS Bin will, at its expense, use all reasonable commercial endeavours to correct any such non-conformance promptly, or provide the User with an alternative means of accomplishing the desired performance. Such correction or substitution constitutes the User's sole and exclusive remedy for any breach of the undertaking set out in clause 7.1.  Notwithstanding the foregoing, JS Bin:
 
             1. does not warrant that the User's use of the Services will be uninterrupted or error-free; or that the Services, Documentation and/or the information obtained by the User through the Services will meet the User's requirements; and
             * is not responsible for any delays, delivery failures, or any other loss or damage resulting from the transfer of data over communications networks and facilities, including the internet, and the User acknowledges that the Services and Documentation may be subject to limitations, delays and other problems inherent in the use of such communications facilities.
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       We'll do our best to keep JS Bin up and running, but sometimes is won't be, and when it's not, we'll be working on getting JS Bin back right pretty darn quickly.
 
   .legal
@@ -374,12 +374,12 @@ small Last updated June 12, 2014
         td
           h2 7.3.
         td
-          :markdown
+          :marked
             JS Bin shall, in providing the Services, comply with our privacy policy relating to the privacy and security of your data held by us. Such privacy policy is available from the JS Bin Site or such other website address as may be notified to you from time to time. The privacy policy may be amended from time to time by JS Bin in its sole discretion.
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       This document can change over time. We'll update the timestamp at the top of this document, along with [revisions](https://github.com/jsbin/learn/commits/master/public/legals/index.jade) in our open source repository.
 
   .legal
@@ -388,7 +388,7 @@ small Last updated June 12, 2014
         td
           h2 7.4.
         td
-          :markdown
+          :marked
             If JS Bin processes any personal data on your behalf when performing our obligations under these Terms, we agree that you shall be the data controller and JS Bin shall be a data processor and in any such case:
 
             1. you acknowledge and agree that the personal data may be transferred or stored outside the EEA or the country where you are located in order to carry out the Services and JS Bin’s other obligations under these Terms;
@@ -397,8 +397,8 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       Together, we'll keep your personal information safe.
 
   hr
@@ -413,13 +413,13 @@ small Last updated June 12, 2014
         td
           h2 8.1.
         td
-          :markdown
+          :marked
             You warrant that you are legally entitled to enter into and be bound by these Terms.
       tr
         td
           h2 8.2.
         td
-          :markdown
+          :marked
             You shall:
 
             1. provide JS Bin with all necessary co-operation in relation to these Terms in order to allow us to provide the Services;
@@ -431,13 +431,13 @@ small Last updated June 12, 2014
         td
           h2 8.3.
         td
-          :markdown
+          :marked
             You acknowledge that you are solely responsible for procuring and maintaining your network connections and telecommunications links, and all problems, conditions, delays, delivery failures and all other loss or damage arising from or relating to your network connections or telecommunications links or caused by the internet.
       tr
         td
           h2 8.4.
         td
-          :markdown
+          :marked
             You shall not access, store, distribute or transmit any  material (in the Content or otherwise) during the course of your use of the Services that:
 
             1. is unlawful, harmful, threatening, defamatory, obscene, infringing, harassing or racially or ethnically offensive;
@@ -450,7 +450,7 @@ small Last updated June 12, 2014
         td
           h2 8.5.
         td
-          :markdown
+          :marked
             You further agree not to:
 
             1. impersonate any person or entity of falsely state or otherwise present your affiliation with a person or entity;
@@ -466,8 +466,8 @@ small Last updated June 12, 2014
             * use the JS Bin Site for any illegal or unauthorised purpose. You must not, in the use of the JS Bin Site and the Services, breach any laws in your jurisdiction (including but not limited to copyright laws).
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       Don't be a Jerk™.
 
       Seriously. Don't do it.
@@ -478,12 +478,12 @@ small Last updated June 12, 2014
         td
           h2 8.6.
         td
-          :markdown
+          :marked
             For the avoidance of doubt any breach by you of any of these Terms (which constitute conditions of your use) shall entitle JS Bin, in its sole discretion, without liability (including in relation to any payment made in relation to your Account) or prejudice to its other rights, to remove or refuse to distribute any Content  via the Services and to disable your access to your Account and to terminate Users and reclaim User names. We also reserve the right to access, read, preserve, and disclose (to any competent authority) any information as we reasonably believe is necessary to (i) satisfy any applicable law, regulation, legal process or governmental request, (ii) enforce these Terms of Use, including investigation of potential breaches hereof, (iii) detect, prevent or otherwise address fraud, security or technical issues, (iv) respond to User support requests, or (v) protect the rights of JS Bin, its Users, legitimate business interests and the public.
   .ourwords
     p.mean In other words,
-    :markdown
 
+    :marked
       If you do break the rules of good conduct, we can terminate your account.
 
   hr
@@ -498,18 +498,18 @@ small Last updated June 12, 2014
         td
           h2 9.1.
         td
-          :markdown
+          :marked
             You acknowledge and agree that JS Bin and/or its licensors own all intellectual property rights in the JS Bin Site, the Software, the Services and the Documentation. Except as expressly stated herein, these Terms do not grant you any rights to, or in, patents, copyright, database right, trade secrets, trade names, trade marks (whether registered or unregistered), or any other rights or licences in respect of the JS Bin Site, the Software, the Services or the Documentation.
       tr
         td
           h2 9.2.
         td
-          :markdown
+          :marked
             All right, title and interest in Content generated by you shall be proprietary to you (but shall be subject to the licence granted by clause 5.1).
 
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       JS Bin belongs to us. Your Bins belongs to you.
 
   hr
@@ -524,12 +524,12 @@ small Last updated June 12, 2014
         td
           h2 10.1.
         td
-          :markdown
+          :marked
             You acknowledge that you will be solely and fully responsible for all liabilities incurred through the use of your Account and the Services. You shall defend, indemnify and hold harmless JS Bin against claims, actions, proceedings, losses, damages, expenses and costs (including without limitation court costs and reasonable legal fees) arising out of or in connection with your use of the Account, the Services and/or the Documentation including, but not limited to, any liability arising from or resulting from the Content uploaded to your Bin including infringement of third party intellectual property or laws or civil or criminal claims
 
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       You alone are responsible for the Bins and the content you create and post.
 
   hr
@@ -544,13 +544,13 @@ small Last updated June 12, 2014
         td
           h2 11.1.
         td
-          :markdown
+          :marked
             You understand, agree and accept that your use of the JS Bin Site and the Services is at your own discretion and risk and that you will be solely responsible for loss of data that results from the submission or download of such content.
       tr
         td
           h2 11.2.
         td
-          :markdown
+          :marked
             This clause 11 sets out the entire financial liability of JS Bin (including any liability for the acts or omissions of its employees, agents and sub-contractors) to you:
 
             1. arising under or in connection with these Terms;
@@ -560,7 +560,7 @@ small Last updated June 12, 2014
         td
           h2 11.3.
         td
-          :markdown
+          :marked
             Except as expressly and specifically provided in this agreement:
 
             1. you assume sole responsibility for results obtained from your use of the JS Bin Site, the Services and the Documentation, and for conclusions drawn from such use. JS Bin shall have no liability for any damage caused by errors or omissions in any information, instructions or scripts provided to JS Bin by you in connection with the Services, or any actions taken by JS Bin at your direction;
@@ -570,7 +570,7 @@ small Last updated June 12, 2014
         td
           h2 11.4.
         td
-          :markdown
+          :marked
             JS Bin does not warrant:
 
             1. that the provision of operation of the JS Bin Site or provision of the Services will be uninterrupted, secure, reliable, timely or error-free;
@@ -583,7 +583,7 @@ small Last updated June 12, 2014
         td
           h2 11.5.
         td
-          :markdown
+          :marked
             Nothing in these Terms excludes the liability of JS Bin:
 
             1. for death or personal injury caused by JS Bin’s negligence; or
@@ -592,7 +592,7 @@ small Last updated June 12, 2014
         td
           h2 11.6.
         td
-          :markdown
+          :marked
             Subject to clause 11.3 and clause 11.4:
 
             1. JS Bin shall not be liable whether in tort (including for negligence or breach of statutory duty), contract, misrepresentation, restitution or otherwise for any loss of profits, loss of business, depletion of goodwill and/or similar losses or loss or corruption of data or information, or pure economic loss, or for any special, indirect or consequential loss, costs, damages, charges or expenses however arising under these Terms; and
@@ -600,7 +600,7 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       JS Bin is not liable for misuse of the service. For example, don't run your business through JS Bin.
 
 
@@ -616,23 +616,23 @@ small Last updated June 12, 2014
         td
           h2 12.1.
         td
-          :markdown
+          :marked
             You are solely responsible for properly cancelling your Account. You can cancel your Account at any time by logging in to the [settings page](http://jsbin.com/account) and following the instructions.
       tr
         td
           h2 12.2.
         td
-          :markdown
+          :marked
             Any cancellation of your Account will result in deactivation or deletion of your Account or your access to your Account, and the forfeiture and relinquishment of all Content in your Account. This information cannot be recovered from JS Bin once your Account is cancelled. JS Bin may, but is not obliged to, retain residual information in backup and/or archival copies on our database but we will use reasonable commercial efforts to delete your information as soon as possible after you communicate that intention to us.
       tr
         td
           h2 12.3.
         td
-          :markdown
+          :marked
             Cancellations will take effect immediately but you will not be entitled to any refunds for unused time relating to your Account Service period.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       You are responsible for cancelling your Pro account, after which you will not have access to Pro features.
 
   .legal
@@ -641,11 +641,11 @@ small Last updated June 12, 2014
         td
           h2 12.4.
         td
-          :markdown
+          :marked
             JS Bin, in its sole discretion, has the right to suspend or terminate your Account if (a) you breach these Terms (including failing to make any payments falling due) or (2) your bandwidth usage significantly exceeds the average bandwidth of other users of the Services. In each case JS Bin may refuse to provide you any current or future use of the JS Bin Site, or any other services. Any termination of your Account will result in the deactivation or deletion of your Account or your access to your Account, and the forfeiture and relinquishment of all Content in your Account. This information cannot be recovered from JS Bin once your Account is terminated.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       But also, if you break the rules, we'll cancel your account for you.
 
   hr
@@ -660,12 +660,12 @@ small Last updated June 12, 2014
         td
           h2 13.1.
         td
-          :markdown
+          :marked
             JS Bin shall have no liability to you under these Terms if we are prevented from or delayed in performing our obligations under these Terms, or from carrying on its business, by acts, events, omissions or accidents beyond our reasonable control, including, without limitation, strikes, lock-outs or other industrial disputes (whether involving the workforce of the Supplier or any other party), failure of a utility service or transport or telecommunications network, act of God, war, riot, civil commotion, malicious damage, compliance with any law or governmental order, rule, regulation or direction, accident, breakdown of plant or machinery, fire, flood, storm or default of suppliers or sub-contractors.
 
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       Come The Apocalypse...etc, JS Bin won't be held resposible.
 
   hr
@@ -679,12 +679,12 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             JS Bin may  update the Terms from time to time without notice and any changes will be binding on you. You agree to review these Terms regularly and we are entitled to treat your continued access to or use of the Services as confirmation that you agree to the changes.
 
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       These terms will update, but the [history](https://github.com/jsbin/learn/commits/master/public/legals/index.jade) is in our repo.
 
   hr
@@ -698,11 +698,11 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             No failure or delay by a party to exercise any right or remedy provided under these Terms or by law shall constitute a waiver of that or any other right or remedy, nor shall it prevent or restrict the further exercise of that or any other right or remedy. No single or partial exercise of such right or remedy shall prevent or restrict the further exercise of that or any other right or remedy.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       These terms won't be waivered.
 
   hr
@@ -716,11 +716,11 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             Except as expressly provided in these Terms, the rights and remedies provided under these Terms are in addition to, and not exclusive of, any rights or remedies provided by law.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       The Law, is The Law.
 
   hr
@@ -735,17 +735,17 @@ small Last updated June 12, 2014
         td
           h2 17.1.
         td
-          :markdown
+          :marked
             If any provision (or part of a provision) of these Terms is found by any court or administrative body of competent jurisdiction to be invalid, unenforceable or illegal, the other provisions shall remain in force.
       tr
         td
           h2 17.2.
         td
-          :markdown
+          :marked
             If any invalid, unenforceable or illegal provision would be valid, enforceable or legal if some part of it were deleted, the provision shall apply with whatever modification is necessary to give effect to the commercial intention of the parties.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       If anything is found to be wrong in these Terms, the rest still applies.
 
   hr
@@ -760,17 +760,17 @@ small Last updated June 12, 2014
         td
           h2 18.1.
         td
-          :markdown
+          :marked
             These Terms, and any documents referred to in them, constitute the whole agreement between the parties and supersede any previous arrangement, understanding or agreement between them relating to the subject matter they cover.
       tr
         td
           h2 18.2.
         td
-          :markdown
+          :marked
             Both you and JS Bin acknowledge and agree that in entering into these Terms that we do not rely on any undertaking, promise, assurance, statement, representation, warranty or understanding (whether in writing or not) of any person (whether party to this agreement or not) relating to the subject matter of this agreement, other than as expressly set out in these Terms.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       These are the terms.
 
   hr
@@ -784,11 +784,11 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             You shall not assign, transfer, charge, sub-contract or deal in any other manner with all or any of your rights or obligations under these Terms. JS Bin may at any time assign, transfer, charge, sub-contract or deal in any other manner with all or any of its rights or obligations under these Terms.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       Don't re-sell JS Bin.
 
   hr
@@ -802,11 +802,11 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             These Terms and any dispute or claim arising out of or in connection with it or its subject matter or formation (including non-contractual disputes or claims) shall be governed by and construed in accordance with the law of England and Wales.
   .ourwords
     p.mean In other words,
-    :markdown
+    :marked
       We're based in England, so we're governed by law of England and Wales.
 
   .legal
@@ -819,5 +819,5 @@ small Last updated June 12, 2014
       tr
         td &nbsp;
         td
-          :markdown
+          :marked
             Each party irrevocably agrees that the courts of England and Wales shall have exclusive jurisdiction to settle any dispute or claim arising out of or in connection with these Terms or their subject matter or formation (including non-contractual disputes or claims).

--- a/public/legals/index.jade
+++ b/public/legals/index.jade
@@ -46,7 +46,6 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-
     :marked
       This mighty document is our legal terms. Exciting stuff, but worth taking a few minutes to look through to understand what it means to you.
 
@@ -92,7 +91,6 @@ small Last updated June 12, 2014
             These Terms will apply for as long as you use the JS Bin Site and/or the Services. Any part of these Terms that by necessity or implication are to continue after your use of the JS Bin Site or the Services ends (including the licence under clause 5.1) shall continue in force.
   .ourwords
     p.mean In other words,
-
     :marked
       There are a few rules which we need to play by. We run jsbin.com and all the sites under that domain.
 
@@ -139,7 +137,6 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-
     :marked
       If you use JS Bin, you're bound by these terms. If you create an account, please use your own email address.
 
@@ -158,7 +155,6 @@ small Last updated June 12, 2014
             You are responsible for all content, code, features, comments, graphics or text that you may post on the JS Bin Site (the ‘**Content**’) and activity that occurs under your Account (even when Content is posted by others who have access to your Account).
   .ourwords
     p.mean In other words,
-
     :marked
       You are responsible for the content in your Bins. Don't go infringing on other people's copyrights.
 
@@ -191,7 +187,6 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-
     :marked
       You can use JS Bin on jsbin.com. Also, JS Bin is [open source](http://github.com/jsbin/jsbin) and MIT licensed, so you can use it where you want too.
 
@@ -217,7 +212,6 @@ small Last updated June 12, 2014
             If you specifically save a Bin as private on the JS Bin Site, and that Bin has never been public on the JS Bin Site or anywhere else, the code in that particular Bin is unlicensed.
    .ourwords
     p.mean In other words,
-
     :marked
       Public Bins you build on JS Bin are MIT licensed, meaning other people are free to use it for whatever they like as long as that is also [MIT licensed](http://jsbin.mit-license.org). Don't put anything on JS Bin where that wouldn't be okay. Private Bins are un-licensed so that you may apply your own license and retain direct ownership.
 
@@ -231,7 +225,6 @@ small Last updated June 12, 2014
             You agree that the licence in clause 5.1 includes the right for JS Bin and other users of the Services to make your Content available to others for the publication, distribution, syndication, or broadcast of such Content on other media and services, subject to our terms and conditions for such Content use. Such additional uses by JS Bin or others may be made with no compensation paid to you with respect to the Content that you submit, post, transmit or otherwise make available through the Services.
    .ourwords
     p.mean In other words,
-
     :marked
       People don't have to pay to see your Bins.
 
@@ -245,7 +238,6 @@ small Last updated June 12, 2014
             JS Bin may modify or adapt your Content in order to transmit, display or distribute it over computer networks and in various media and/or make changes to your Content as are necessary to conform and adapt that Content to any requirements or limitations of any networks, devices, services or media.
    .ourwords
     p.mean In other words,
-
     :marked
       People can create clones of your Bins.
 
@@ -263,7 +255,6 @@ small Last updated June 12, 2014
             * infringes any intellectual property right of another or the privacy or publicity rights of another.
    .ourwords
     p.mean In other words,
-
     :marked
       Don't infringe on other people's copyright.
 
@@ -286,7 +277,6 @@ small Last updated June 12, 2014
 
    .ourwords
     p.mean In other words,
-
     :marked
       We don't monitor what you post on JS Bin, nor are liable for what's posted, so if you see something that breaks the rules, [please let us know](mailto:jsbin@leftlogic.com).
 
@@ -332,7 +322,6 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-
     :marked
       All sales are final. You'll be billed on the 30th day after creating a paid for account.
 
@@ -364,7 +353,6 @@ small Last updated June 12, 2014
             * is not responsible for any delays, delivery failures, or any other loss or damage resulting from the transfer of data over communications networks and facilities, including the internet, and the User acknowledges that the Services and Documentation may be subject to limitations, delays and other problems inherent in the use of such communications facilities.
   .ourwords
     p.mean In other words,
-
     :marked
       We'll do our best to keep JS Bin up and running, but sometimes is won't be, and when it's not, we'll be working on getting JS Bin back right pretty darn quickly.
 
@@ -378,7 +366,6 @@ small Last updated June 12, 2014
             JS Bin shall, in providing the Services, comply with our privacy policy relating to the privacy and security of your data held by us. Such privacy policy is available from the JS Bin Site or such other website address as may be notified to you from time to time. The privacy policy may be amended from time to time by JS Bin in its sole discretion.
   .ourwords
     p.mean In other words,
-
     :marked
       This document can change over time. We'll update the timestamp at the top of this document, along with [revisions](https://github.com/jsbin/learn/commits/master/public/legals/index.jade) in our open source repository.
 
@@ -397,7 +384,6 @@ small Last updated June 12, 2014
 
   .ourwords
     p.mean In other words,
-
     :marked
       Together, we'll keep your personal information safe.
 
@@ -466,7 +452,6 @@ small Last updated June 12, 2014
             * use the JS Bin Site for any illegal or unauthorised purpose. You must not, in the use of the JS Bin Site and the Services, breach any laws in your jurisdiction (including but not limited to copyright laws).
   .ourwords
     p.mean In other words,
-
     :marked
       Don't be a Jerk™.
 
@@ -482,7 +467,6 @@ small Last updated June 12, 2014
             For the avoidance of doubt any breach by you of any of these Terms (which constitute conditions of your use) shall entitle JS Bin, in its sole discretion, without liability (including in relation to any payment made in relation to your Account) or prejudice to its other rights, to remove or refuse to distribute any Content  via the Services and to disable your access to your Account and to terminate Users and reclaim User names. We also reserve the right to access, read, preserve, and disclose (to any competent authority) any information as we reasonably believe is necessary to (i) satisfy any applicable law, regulation, legal process or governmental request, (ii) enforce these Terms of Use, including investigation of potential breaches hereof, (iii) detect, prevent or otherwise address fraud, security or technical issues, (iv) respond to User support requests, or (v) protect the rights of JS Bin, its Users, legitimate business interests and the public.
   .ourwords
     p.mean In other words,
-
     :marked
       If you do break the rules of good conduct, we can terminate your account.
 


### PR DESCRIPTION
The following scripts execute without errors:

1. `npm run test`
2. `npm run compile`
3. `npm run start`

Using `export NODE_ENV=test` and `npm run start` I am able to view the help and blog pages successfully. 

**Help**

![screen shot 2017-05-23 at 10 31 13 am](https://cloud.githubusercontent.com/assets/1824760/26362278/13b4bb38-3fa3-11e7-8ca6-2eaf233d9f29.png)

**Blog**

![screen shot 2017-05-23 at 10 31 24 am](https://cloud.githubusercontent.com/assets/1824760/26362290/1a99402c-3fa3-11e7-8a92-8b8e1204368c.png)

**NOTE**:

`export NODE_ENV=production` and `npm run start` still need verification

Related Issue: [JS Bin help (and blog) is offline](https://github.com/jsbin/jsbin/issues/3054)